### PR TITLE
Fix order of outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install pypiqe
 ```
 from pypiqe import piqe
 
-score, activityMask, noticeableArtifactMask, noiseMask = piqe(I)
+score, noticeableArtifactMask, noiseMask, activityMask = piqe(I)
 ```
 
 ## Description

--- a/pypiqe/piqe.py
+++ b/pypiqe/piqe.py
@@ -76,7 +76,7 @@ def piqe(I):
     #   # NoiseMask for a JP2K compressed image with added AWGN noise patch.
     #
     #   I = imread('DistortedImage.png');
-    #   [Score, ActivityMask, NoticeableArtifactsMask, NoiseMask] = piqe(I);
+    #   [Score, NoticeableArtifactsMask, NoiseMask, ActivityMask] = piqe(I);
     #   J  = labeloverlay(I, ActivityMask, 'Colormap', 'winter', 'Transparency', 0.25);
     #   K  = labeloverlay(I, NoticeableArtifactsMask, 'Colormap', 'autumn', 'Transparency', 0.25);
     #   L  = labeloverlay(I, NoiseMask, 'Colormap', 'hot', 'Transparency', 0.25);


### PR DESCRIPTION
Updated the order of the outputs in the README and example section of the piqe.py file, to reflect the actual order of the outputs.